### PR TITLE
GHA: add reusable GitHub action

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-22.04
     environment: publish-tags
 
-    # Only publish tags when it's a release,
-    # or when pushing to PyPI production (not test PyPI).
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pypi_repo == 'pypi')
+    # Only publish tags when it's a final/stable release.
+    # If it's a pre-released then `github.event.action` is set to 'prereleased'.
+    if: github.event_name == 'release' && github.event.action == 'released'
 
     permissions:
       contents: write
@@ -68,8 +68,8 @@ jobs:
         run: |
           version="${GITHUB_REF#refs/tags/}"
 
-          # Validate the tag starts with "v<major>.<minor>.<patch>"
-          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          # Validate the tag is "v<major>.<minor>.<patch>"
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Expected the tag to start with vX.X but found '${version}'" >&2
             exit 1
           fi
@@ -90,7 +90,6 @@ jobs:
 
     needs:
       - build
-      - push-tags
 
     permissions:
       id-token: write  # Required for PyPI trusted publishing

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -44,12 +44,53 @@ jobs:
           if-no-files-found: error
           retention-days: 5
 
+  push-tags:
+    runs-on: ubuntu-22.04
+    environment: publish-tags
+
+    # Only publish tags when it's a release,
+    # or when pushing to PyPI production (not test PyPI).
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pypi_repo == 'pypi')
+
+    permissions:
+      contents: write
+
+    needs:
+      # Ensure the build succeeds before pushing additional tags.
+      - build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - shell: bash
+        name: Update Major Version Tag
+        run: |
+          version="${GITHUB_REF#refs/tags/}"
+
+          # Validate the tag starts with "v<major>.<minor>.<patch>"
+          if [[ ! "$version" =~ ^v[0-9]\.[0-9]\.[0-9] ]]; then
+            echo "Expected the tag to start with vX.X but found '${version}'" >&2
+            exit 1
+          fi
+          
+          # v0.1.0 -> v0
+          # v1.2.3 -> v1
+          # etc.
+          short_tag=$(echo "$version" | cut -d. -f1)
+          
+          # --force is needed in order to replace the tags.
+          # Note: --force-with-lease doesn't work for replacing tags.
+          git tag --force "$short_tag"
+          git push origin --force "refs/tags/${short_tag}"
+
   publish:
     runs-on: ubuntu-22.04
     environment: publish-pypi
 
     needs:
       - build
+      - push-tags
 
     permissions:
       id-token: write  # Required for PyPI trusted publishing

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -69,7 +69,7 @@ jobs:
           version="${GITHUB_REF#refs/tags/}"
 
           # Validate the tag starts with "v<major>.<minor>.<patch>"
-          if [[ ! "$version" =~ ^v[0-9]\.[0-9]\.[0-9] ]]; then
+          if [[ ! "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "Expected the tag to start with vX.X but found '${version}'" >&2
             exit 1
           fi

--- a/.github/workflows/run-shellcheck.yaml
+++ b/.github/workflows/run-shellcheck.yaml
@@ -5,13 +5,12 @@ on:
       - .github/workflows/**
     branches:
       - main
-      - master
   pull_request:
     paths:
       - .github/workflows/**
   workflow_dispatch:
     inputs:
-      SCAN_DIRECTORY:
+      scan-directory:
         default: .github/workflows
         description: The directory containing GitHub workflows YAML files to scan.
         required: false
@@ -20,9 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  check:
     env:
-      POETRY_VIRTUALENVS_CREATE: "false"
       DEFAULT_SCAN_DIRECTORY: .github/workflows
 
     runs-on: ubuntu-22.04
@@ -32,28 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Setup Python
-        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
-        with:
-          python-version-file: .github/requirements/python-version.txt
-
-      - name: ShellCheck Version
-        run: |
-          shellcheck --version
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install -r .github/requirements/requirements-poetry.txt
-          poetry install
-
       - name: Run ShellCheck
-        shell: bash
-        env:
-          SCAN_DIRECTORY: ${{ inputs.SCAN_DIRECTORY || env.DEFAULT_SCAN_DIRECTORY }}
-        run: |
-          set -u -o pipefail
-          
-          cmd_args=()
-          test -z "${RUNNER_DEBUG+x}" || cmd_args+=( "--debug" )
-          
-          poetry run shellcheck-gha "${cmd_args[@]}" -- "$SCAN_DIRECTORY"
+        uses: ./
+        with:
+          scan-directory-path: ${{ inputs.scan-directory || env.DEFAULT_SCAN_DIRECTORY }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This Python script extracts shell scripts from GitHub workflows
 <!-- TOC -->
 * [shellcheck-gha](#shellcheck-gha)
   * [Installation](#installation)
-    * [PyPI (recommended)](#pypi-recommended)
+    * [Using GitHub Actions (recommended)](#using-github-actions-recommended)
+    * [PyPI](#pypi)
     * [From Source](#from-source)
   * [Usage](#usage)
   * [Example](#example)
@@ -26,7 +27,34 @@ This Python script extracts shell scripts from GitHub workflows
 - Python ≥ 3.11
 - [ShellCheck] ≥ 0.9.0, available on `apt`, `brew`, `cabal`, `dnf`, and `pkg`.
 
-### PyPI (recommended)
+### Using GitHub Actions (recommended)
+
+The `shellcheck-gha` project can be used as a GitHub Workflow step:
+
+```yaml
+on:
+  push:
+    paths:
+      - .github/workflows/**
+  pull_request:
+    paths:
+      - .github/workflows/**
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: saleor/shellcheck-gha@v0
+```
+
+### PyPI
 
 The project is hosted on PyPI at https://pypi.org/project/shellcheck-gha/.
 To install the project, run:
@@ -85,7 +113,7 @@ Scanned 5 files (16 shell scripts)
     Message: Double quote to prevent globbing and word splitting.
     More information: https://www.shellcheck.net/wiki/SC2086
     Code:
-        echo $BAD_JOB1
+        echo $BAD_JOB2
              ^^^^^^^^^^
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,47 @@
+name: ShellCheck GitHub Workflows
+description: >
+  Extracts and checks shell scripts in Github Workflows for potential issues
+  using ShellCheck.
+inputs:
+  scan-directory-path:
+    default: .github/workflows
+    description: The directory containing GitHub workflows YAML files to scan.
+    required: false
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      with:
+        python-version-file: ${{ github.action_path }}/.github/requirements/python-version.txt
+
+    - name: Install Dependencies
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      # Groups allow to collapse by default the noisy installation steps.
+      # It's a mitigation for this: https://github.com/orgs/community/discussions/21276.
+      run: |
+        echo "::group::Install Dependencies"
+        python -m pip install -r .github/requirements/requirements-poetry.txt
+        poetry env use "$(which python)"
+        poetry install
+        echo "$(poetry env info -p)"/bin >> "$GITHUB_PATH"
+        echo "::endgroup::"
+
+    - name: ShellCheck Version
+      shell: bash
+      run: |
+        shellcheck --version
+
+    - name: Run ShellCheck
+      shell: bash
+      env:
+        SCAN_DIRECTORY: ${{ inputs.scan-directory-path }}
+      run: |
+        set -u -o pipefail
+        
+        cmd_args=()
+        test -z "${RUNNER_DEBUG+x}" || cmd_args+=( "--debug" )
+        
+        shellcheck-gha "${cmd_args[@]}" -- "$SCAN_DIRECTORY"


### PR DESCRIPTION
This adds `action.yaml` to allow users to invoke `semgrep-gha` as a GitHub Workflow step directly.

This also adds logic in publish workflow to push (create and/or update) the major version tag (e.g., `v0`, `v1`, etc.)