### PR TITLE
ux: include YAML file path on schema mismatch

### DIFF
--- a/shellcheck_gha/models/github_action.py
+++ b/shellcheck_gha/models/github_action.py
@@ -76,5 +76,6 @@ class GitHubYAML(BaseModel):
             # This code should never be reached unless a non-GitHub workflow or action
             # YAML file was provided to the CLI.
             raise UnknownYAMLFileException(
-                "The YAML file should contain either 'jobs' or 'runs'."
+                "The YAML file should contain either 'jobs' or 'runs'.",
+                yaml_path,
             )

--- a/tests/models/test_github_action.py
+++ b/tests/models/test_github_action.py
@@ -13,8 +13,12 @@ def test_iter_shell_scripts_raises_on_unknown_file_type():
     """
 
     parsed = GitHubYAML.model_validate({"foo": "bar"})
+    yaml_path = Path("dummy")
 
     with pytest.raises(UnknownYAMLFileException) as exc:
-        list(parsed.iter_shell_scripts(Path("dummy")))
+        list(parsed.iter_shell_scripts(yaml_path))
 
-    assert exc.value.args == ("The YAML file should contain either 'jobs' or 'runs'.",)
+    assert exc.value.args == (
+        "The YAML file should contain either 'jobs' or 'runs'.",
+        yaml_path,
+    )


### PR DESCRIPTION
The `UnknownYAMLFileException` exception now includes the YAML file path when raised in order to allow the users to know which file couldn't be parsed.

Example output:

```
$ shellcheck-gha .github/
Traceback (most recent call last):
  File "/python/bin/shellcheck-gha", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/app/shellcheck-github-workflows/shellcheck_gha/console/app.py", line 56, in main
    ).run()
      ^^^^^
  File "/app/shellcheck-github-workflows/shellcheck_gha/extractor.py", line 102, in run
    for snippet in parsed_yaml.iter_shell_scripts(yaml_path):
  File "/app/shellcheck-github-workflows/shellcheck_gha/models/github_action.py", line 78, in iter_shell_scripts
    raise UnknownYAMLFileException(
shellcheck_gha.models.github_action.UnknownYAMLFileException: ("The YAML file should contain either 'jobs' or 'runs'.", PosixPath('/app/shellcheck-github-workflows/.github/invalid.yml'))
```