### PR TITLE
feature: scan .github directory as a whole by default

### DIFF
--- a/.github/workflows/run-shellcheck.yaml
+++ b/.github/workflows/run-shellcheck.yaml
@@ -2,16 +2,16 @@ name: Run ShellCheck
 on:
   push:
     paths:
-      - .github/workflows/**
+      - .github/
     branches:
       - main
   pull_request:
     paths:
-      - .github/workflows/**
+      - .github/
   workflow_dispatch:
     inputs:
       scan-directory:
-        default: .github/workflows
+        default: .github/
         description: The directory containing GitHub workflows YAML files to scan.
         required: false
 
@@ -21,7 +21,7 @@ permissions:
 jobs:
   check:
     env:
-      DEFAULT_SCAN_DIRECTORY: .github/workflows
+      DEFAULT_SCAN_DIRECTORY: .github/
 
     runs-on: ubuntu-22.04
     name: ShellCheck

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ The `shellcheck-gha` project can be used as a GitHub Workflow step:
 on:
   push:
     paths:
-      - .github/workflows/**
+      - .github/**
   pull_request:
     paths:
-      - .github/workflows/**
+      - .github/**
 
 permissions:
   contents: read
@@ -52,7 +52,16 @@ jobs:
 
       - name: Run ShellCheck
         uses: saleor/shellcheck-gha@v0
+        # Uncomment to customize the scan directory:
+        # with:
+        #   scan-directory-path: .github/
 ```
+
+> [!IMPORTANT]  
+> By default only the `./.github` directory is scanned (recursively).
+> If some GitHub Composite actions are defined outside the `.github` directory,
+> consider adding steps to scan the additional directories by changing the `scan-directory-path`
+> parameter.
 
 ### PyPI
 

--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,7 @@ description: >
   using ShellCheck.
 inputs:
   scan-directory-path:
-    default: .github/workflows
+    default: .github/
     description: The directory containing GitHub workflows YAML files to scan.
     required: false
 runs:

--- a/shellcheck_gha/console/app.py
+++ b/shellcheck_gha/console/app.py
@@ -9,7 +9,7 @@ from shellcheck_gha.extractor import Extractor, DEFAULT_SHELL
 
 def parse_args(args: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("directory", nargs="?", default=".github/workflows")
+    parser.add_argument("directory", nargs="?", default=".github/")
     parser.add_argument(
         "--default-shell",
         help="The default shell running in the workflow(s)",


### PR DESCRIPTION
Following https://github.com/saleor/shellcheck-gha/pull/6, this PR changes the default scan directory from `./.github/workflows` to `./.github` as it allows to gather all composite actions which are usually contained under `./.github/actions/`.

This thus ensures that by default, `shellcheck-gha` will be scanning both composite actions and GitHub workflows. But it is also important to keep in mind that composite actions can live outside `./.github/` thus may require users to tweak configurations.