### PR TITLE
Bump version to v0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "shellcheck-gha"
 description = "Extracts and checks shell scripts in Github Workflows for potential issues using shellcheck (https://github.com/koalaman/shellcheck)."
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.2"
 authors = ["Saleor Commerce <hello@saleor.io>"]
 license = "BSD-3-Clause"
 repository = "https://github.com/saleor/shellcheck-gha"


### PR DESCRIPTION
⚠️ This changes the project version from v0.1.0 to v0.1.2; it skips a patch version due v0.1.1 being accidentally published at https://github.com/saleor/shellcheck-gha/releases/tag/v0.1.1 without updating the Python (and thus PyPI) package's version.

Changes:
* ux: include YAML file path on schema mismatch
* feature: ignore unsupported YAML files
* feature: scan .github directory as a whole by default