### PR TITLE
fix: flaky tests caused by inconsistent ordering

### DIFF
--- a/shellcheck_gha/extractor.py
+++ b/shellcheck_gha/extractor.py
@@ -40,7 +40,7 @@ class Extractor:
 
     def iter_workflow_paths(self):
         """Yields all yaml files recursively."""
-        for path in self.directory.rglob("*"):
+        for path in sorted(self.directory.rglob("*")):
             if (
                 path.is_file()
                 and not path.is_symlink()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -17,6 +17,12 @@ def test_render_findings_human():
 
     actual = "".join(ResultRenderer().render(findings))
     expected = f"""\
+[\x1b[36mINFO\x1b[39m] In {samples.PATH / "composite-action.yaml"}:
+    Message: Double quote to prevent globbing and word splitting.
+    More information: https://www.shellcheck.net/wiki/SC2086
+    Code:
+        echo $BAD_COMPOSITE_ACTION
+             ^^^^^^^^^^^^^^^^^^^^^^
 [\x1b[36mINFO\x1b[39m] In {samples.PATH / "gh-workflow.yaml"}:
     Message: Double quote to prevent globbing and word splitting.
     More information: https://www.shellcheck.net/wiki/SC2086
@@ -29,11 +35,5 @@ def test_render_findings_human():
     Code:
         echo $BAD_JOB2
              ^^^^^^^^^^
-[\x1b[36mINFO\x1b[39m] In {samples.PATH / "composite-action.yaml"}:
-    Message: Double quote to prevent globbing and word splitting.
-    More information: https://www.shellcheck.net/wiki/SC2086
-    Code:
-        echo $BAD_COMPOSITE_ACTION
-             ^^^^^^^^^^^^^^^^^^^^^^
 """
     assert actual == expected


### PR DESCRIPTION
Tests were flaky due to an unsorted `rglob`, as per CPython docs:
> The paths are returned in no particular order. If you need a specific order, sort the results.

(https://docs.python.org/3.14/library/pathlib.html#pathlib.Path.rglob)

Example logs: https://github.com/saleor/shellcheck-gha/actions/runs/24561888434